### PR TITLE
S3互換製品でも使えるようにバリデーションを省略する

### DIFF
--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -304,7 +304,7 @@ type completeMultipartUploadResult struct {
 // CompletePart sub container lists individual part numbers and their
 // md5sum, part of completeMultipartUpload.
 type CompletePart struct {
-	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ Part" json:"-"`
+	XMLName xml.Name `xml:"Part" json:"-"`
 
 	// Part number identifies the part.
 	PartNumber int
@@ -313,13 +313,13 @@ type CompletePart struct {
 
 // completeMultipartUpload container for completing multipart upload.
 type completeMultipartUpload struct {
-	XMLName xml.Name       `xml:"http://s3.amazonaws.com/doc/2006-03-01/ CompleteMultipartUpload" json:"-"`
+	XMLName xml.Name       `xml:"CompleteMultipartUpload" json:"-"`
 	Parts   []CompletePart `xml:"Part"`
 }
 
 // createBucketConfiguration container for bucket configuration.
 type createBucketConfiguration struct {
-	XMLName  xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ CreateBucketConfiguration" json:"-"`
+	XMLName  xml.Name `xml:"CreateBucketConfiguration" json:"-"`
 	Location string   `xml:"LocationConstraint"`
 }
 


### PR DESCRIPTION

## Description

minio gatewayを利用してDagrinへアップロードする際、Comple Multipart Uploadに失敗する。原因はDagrinからのレスポンスボディのXMLヘッダが

```
<CompleteMultipartUploadResult xmlns="http://acs.dag.iijgio.com/doc/2006-03-01/">
```

だが、minioは

```
<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
```

を期待しているため。結果として以下のようなエラーが発生する。

```
Error: The XML you provided was not well-formed or did not validate against our published schema. (minio.ErrorResponse)
       4: cmd/api-errors.go:2097:cmd.toAPIErrorCode()
       3: cmd/api-errors.go:2122:cmd.toAPIError()
       2: cmd/object-handlers.go:3272:cmd.objectAPIHandlers.CompleteMultipartUploadHandler()
       1: net/http/server.go:2046:http.HandlerFunc.ServeHTTP()
```

そこで、やむなくバリデーションをゆるめる修正を入れる。
